### PR TITLE
Fix AbstractShortUrl / ShortUrl constructor

### DIFF
--- a/Entity/AbstractShortUrl.php
+++ b/Entity/AbstractShortUrl.php
@@ -42,6 +42,15 @@ class AbstractShortUrl implements ShortUrlInterface
     protected $hits;
 
     /**
+     * AbstractShortUrl constructor.
+     */
+    protected function __construct()
+    {
+        $this->customCode = false;
+        $this->hits = 0;
+    }
+
+    /**
      * @return int
      */
     public function getId()

--- a/Entity/ShortUrl.php
+++ b/Entity/ShortUrl.php
@@ -22,8 +22,7 @@ class ShortUrl extends AbstractShortUrl
     public function __construct()
     {
         $this->created = new \DateTime();
-        $this->customCode = false;
-        $this->hits = 0;
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
Moves AbstractShortUrl property initialization ($customCode, $hits) from ShortUrl to AbstractShortUrl
